### PR TITLE
Add Github Actions workflow to auto-generate documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,13 +2,17 @@ root = true
 [*]
 insert_final_newline = true
 end_of_line = 'lf'
+trim_trailing_whitespace = true
 [*.py]
 charset = 'utf8'
-trim_trailing_whitespace = true
 indent_style = 'space'
 indent_size = 4
 [*.js]
 charset = 'utf8'
-trim_trailing_whitespace = true
 indent_style = 'space'
 indent_size = 2
+[*.rst]
+charset = 'utf8'
+indent_style = 'space'
+indent_size = 3
+

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Sphinx build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+- push
+- pull_request
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps are a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check out repository under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+    # Builds docs in the indicated directory using sphinx
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/AboutDoc/"
+    # Create an artifact out of the previously built docs
+    - uses: actions/upload-artifact@v1
+      with:
+        name: AboutDocHTML
+        path: "doc/AboutDoc/_build/html/"
+    # Builds docs in the indicated directory using sphinx
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/"
+    # Create an artifact out of the user guide HTML
+    - uses: actions/upload-artifact@v1
+      with:
+        name: UserGuideHTML
+        path: "doc/_build/html/"
+

--- a/doc/AboutDoc/requirements.txt
+++ b/doc/AboutDoc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx_rtd_theme
+sphinx_copybutton
+

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx_rtd_theme
+sphinx_copybutton
+

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,8 +28,6 @@
 import os
 from time import strftime
 
-from PyQt5.QtCore import QDir
-
 VERSION = "2.5.1-dev2"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.5"
 DATE = "20200228000000"
@@ -98,11 +96,18 @@ except ImportError:
     print("Loading translations from: {}".format(language_path))
 
 # Compile language list from :/locale resource
-langdir = QDir(language_path)
-langs = langdir.entryList(['OpenShot.*.qm'], QDir.NoDotAndDotDot | QDir.Files,
-                          sort=QDir.Name)
-for trpath in langs:
-    SUPPORTED_LANGUAGES.append(trpath.split('.')[1])
+try:
+    from PyQt5.QtCore import QDir
+    langdir = QDir(language_path)
+    langs = langdir.entryList(
+        ['OpenShot.*.qm'],
+        QDir.NoDotAndDotDot | QDir.Files,
+        sort=QDir.Name)
+    for trpath in langs:
+        SUPPORTED_LANGUAGES.append(trpath.split('.')[1])
+except ImportError:
+    # Fail gracefully if we're running without PyQt5 (e.g. CI tasks)
+    pass
 
 SETUP = {
     "name": NAME,


### PR DESCRIPTION
Set up a Github Actions task that will run Sphinx in both the `doc/AboutDoc` and `doc` dirs, generating the configured HTML docs for each directory and publishing them as an artifact from the task. (Two artifacts are generated per run, `AboutDocHTML.zip` and `UserGuideHTML.zip`.)

Artifacts can be downloaded from the job status display on the repo's Actions page.

Other files added/changed:
- `src/classes/info.py`: This is required by the user guide Sphinx configs, and in the Actions it will be running without some dependencies it used to require. The added code works around them being missing without producing any errors.
- `.editorconfig`: Used by some code editors to configure how they format source files. Added some basic configs for `.rst` files.
- `requirements.txt` (in both `doc/` and `doc/AboutDoc/`): Lists the Python module dependencies that need to be installed before running Sphinx. Automatically processed by the Actions workflow.
